### PR TITLE
Update Communism

### DIFF
--- a/src/filters/communist.ts
+++ b/src/filters/communist.ts
@@ -27,9 +27,15 @@ export const communist: Filter = {
   id: "communist",
   name: "Communist",
   description: "This is our filter, comrade!",
+  partial: true,
 
-  run: (message) => ({
-    ...message,
+  // test if message needs to be altered
+  test: (message) => {
+    if (filter(message.content) != message.content) return true
+  },
+  
+  run: (message) => ({ 
+    ...message, 
     content: message.content ? filter(message.content) : message.content,
   }),
 

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -4,10 +4,11 @@ export interface Filter {
   id: string;
   name: string;
   description: string;
+  partial?: boolean;
 
-  run(
-    message: WebhookMessageCreateOptions
-  ): WebhookMessageCreateOptions | Promise<WebhookMessageCreateOptions>;
+  test?(message: WebhookMessageCreateOptions): boolean;
+
+  run(message: WebhookMessageCreateOptions): WebhookMessageCreateOptions | Promise<WebhookMessageCreateOptions>;
 
   preview(text: string, username: string): string | Promise<string>;
 }

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -8,7 +8,9 @@ export interface Filter {
 
   test?(message: WebhookMessageCreateOptions): boolean;
 
-  run(message: WebhookMessageCreateOptions): WebhookMessageCreateOptions | Promise<WebhookMessageCreateOptions>;
+  run(
+    message: WebhookMessageCreateOptions
+  ): WebhookMessageCreateOptions | Promise<WebhookMessageCreateOptions>;
 
   preview(text: string, username: string): string | Promise<string>;
 }

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -93,6 +93,11 @@ export async function applyFilters(
   filters: Filter[]
 ): Promise<WebhookMessageCreateOptions> {
   let newMessage = message;
-  for (const filter of filters) newMessage = await filter.run(newMessage);
+  for (const filter of filters) {
+    if (filter.partial) {
+      await filter.test(newMessage) ? await filter.run(newMessage) : newMessage
+    }
+    newMessage = await filter.run(newMessage);
+  }
   return newMessage;
 }


### PR DESCRIPTION
Altered the function of the communism filter to check if the message has any words to be filtered, and if not, leaves alone.

Currently OmNom will always replace all messages with the filtered webhook message, which works fine for the other filters, however since the communism filter only acts as a "partial" filter (replacing only keywords), it results in messages unnecessarily being replaced with an identical webhook clone, removing the ability to edit/delete the message.

This change will only replace the original message with a webhook message if the OG message contains one of the keywords.

Added an optional "partial" property to the Filter interface (`src/types/filter.ts`, 7). This will specify to `applyFilters()` whether it should proceed with the previously stated check before `filter.run()` (which creates the webhook), as seen in `src/utils/filter.ts` 96-101

Should also add that the following code is completely untested because I am a lazy fuck. May work, may not work. Take the gamble with my professional italian coding technique. I personally have a gambling addiction myself. :)